### PR TITLE
Add GitHub action to build/upload container

### DIFF
--- a/.github/workflows/test_container_build.yml
+++ b/.github/workflows/test_container_build.yml
@@ -12,5 +12,5 @@ jobs:
         id: build-image
         uses: redhat-actions/buildah-build@v2
         with:
-          image: ${{ env.IMAGE_NAME }}
+          image: ae-substracking-interface-test
           dockerfiles: ./Dockerfile

--- a/.github/workflows/test_container_build.yml
+++ b/.github/workflows/test_container_build.yml
@@ -1,0 +1,16 @@
+name: Test Docker container build
+
+on: push
+
+jobs:
+  test:
+    name: Build Docker image
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build image
+        id: build-image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: ${{ env.IMAGE_NAME }}
+          dockerfiles: ./Dockerfile

--- a/.github/workflows/upload_docker_container.yml
+++ b/.github/workflows/upload_docker_container.yml
@@ -1,0 +1,46 @@
+name: Build and upload the ae-substracking-interface Docker image
+
+#on:
+#  release:
+#      types: [published]
+
+on:
+  push:
+      branches: ['main']
+
+env:
+  IMAGE_NAME: ae-substracking-interface
+
+jobs:
+  deploy:
+    name: Build and deploy image to quay.io/ebigxa
+#    if: startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+
+#      - name: Read tag
+#        id: gettag
+#        run: echo ::set-output name=tag::$(echo $GITHUB_REF | cut -d / -f 3)
+
+      - name: Build image
+        id: build-image
+        uses: redhat-actions/buildah-build@v2
+        with:
+          image: ${{ env.IMAGE_NAME }}
+#          tags: latest ${{ steps.gettag.outputs.tag }}
+          dockerfiles: |
+            ./Dockerfile
+
+      - name: Push to Quay
+        id: push-to-quay
+        uses: redhat-actions/push-to-registry@v2
+        with:
+          image: ${{ steps.build-image.outputs.image }}
+#          tags: ${{ steps.build-image.outputs.tags }}
+          registry: quay.io/ebigxa
+          username: ${{ secrets.QUAY_USERNAME }}
+          password: ${{ secrets.QUAY_TOKEN }}
+
+      - name: Use the image
+        run: echo "New image has been pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"

--- a/.github/workflows/upload_docker_container.yml
+++ b/.github/workflows/upload_docker_container.yml
@@ -1,12 +1,12 @@
 name: Build and upload the ae-substracking-interface Docker image
 
-#on:
-#  release:
-#      types: [published]
-
 on:
   push:
       branches: ['main']
+      tags:
+        - "v*.*.*"
+   release:
+      types: [published]
 
 env:
   IMAGE_NAME: ae-substracking-interface
@@ -14,21 +14,21 @@ env:
 jobs:
   deploy:
     name: Build and deploy image to quay.io/ebigxa
-#    if: startsWith(github.ref, 'refs/tags/v')
+    if: startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
 
-#      - name: Read tag
-#        id: gettag
-#        run: echo ::set-output name=tag::$(echo $GITHUB_REF | cut -d / -f 3)
+     - name: Read tag
+       id: gettag
+       run: echo ::set-output name=tag::$(echo $GITHUB_REF | cut -d / -f 3)
 
       - name: Build image
         id: build-image
         uses: redhat-actions/buildah-build@v2
         with:
           image: ${{ env.IMAGE_NAME }}
-#          tags: latest ${{ steps.gettag.outputs.tag }}
+          tags: latest ${{ steps.gettag.outputs.tag }}
           dockerfiles: |
             ./Dockerfile
 
@@ -37,7 +37,7 @@ jobs:
         uses: redhat-actions/push-to-registry@v2
         with:
           image: ${{ steps.build-image.outputs.image }}
-#          tags: ${{ steps.build-image.outputs.tags }}
+          tags: ${{ steps.build-image.outputs.tags }}
           registry: quay.io/ebigxa
           username: ${{ secrets.QUAY_USERNAME }}
           password: ${{ secrets.QUAY_TOKEN }}

--- a/.github/workflows/upload_docker_container.yml
+++ b/.github/workflows/upload_docker_container.yml
@@ -2,12 +2,13 @@ name: Build and upload the ae-substracking-interface Docker image
 
 on:
   push:
-      branches:
-        - main
-      tags:
-        - v*.*.*
-   release:
-      types: [published]
+    branches:
+      - main
+    tags:
+      - v*.*.*
+  release:
+    types:
+      - published
 
 env:
   IMAGE_NAME: ae-substracking-interface

--- a/.github/workflows/upload_docker_container.yml
+++ b/.github/workflows/upload_docker_container.yml
@@ -2,9 +2,10 @@ name: Build and upload the ae-substracking-interface Docker image
 
 on:
   push:
-      branches: ['main']
+      branches:
+        - main
       tags:
-        - "v*.*.*"
+        - v*.*.*
    release:
       types: [published]
 

--- a/.github/workflows/upload_docker_container.yml
+++ b/.github/workflows/upload_docker_container.yml
@@ -21,9 +21,9 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-     - name: Read tag
-       id: gettag
-       run: echo ::set-output name=tag::$(echo $GITHUB_REF | cut -d / -f 3)
+      - name: Read tag
+        id: gettag
+        run: echo ::set-output name=tag::$(echo $GITHUB_REF | cut -d / -f 3)
 
       - name: Build image
         id: build-image

--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,6 @@ dist
 
 # TernJS port file
 .tern-port
+
+.secrets
+.idea/*


### PR DESCRIPTION
This is to automatically generate the Docker image and upload it to the gene expression quay.io repository. 

For the first try I have set the configuration to generate the image upon pushes to the main branch. Ideally in future it should be triggered by tagged releases and the git tag shall be used to name the version of the Docker image. I couldn't test this locally so left the lines commented out for now. 
(Unfortunately, the act tool didn't allow me to fully run the workflow locally because I don't have buildah installed and this only works on Linux. Also there is no option to simulate git tags.)
