### PR TITLE
Implement mechanism to set env name and page colour at build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
+
 FROM node:10-alpine
 
 RUN mkdir -p /home/node/app/node_modules && chown -R node:node /home/node/app
@@ -9,6 +10,11 @@ USER node
 RUN npm install --production
 
 COPY --chown=node:node . .
+
+# To set the name/colour/port of the pages, PROD or TEST. Pass in as e.g. --build-arg env_label=TEST
+ARG env_label=ENVIRONMENT
+ARG env_colour=ENV_COLOUR
+RUN for f in $(ls ui/*.html); do sed -i -e "s/ENVIRONMENT/$env_label/g" $f && sed -i -e "s/ENV_COLOUR/$env_colour/g" $f; done
 
 EXPOSE 3004
 


### PR DESCRIPTION
This represents the previous mechanism (see https://github.com/ebi-gene-expression-group/fgsubs/blob/master/submissions_tracking/api/sbRestApiServer.sh) how the pages were modified to reflect the environment, i.e. which database is being looked at. 
We now have the option to modify the pages at build time via Docker build arguments and set the page colour and name displayed. 
E.g. `docker build  --build-arg env_label=TEST --build-arg env_colour=#28B463 -t subs-interface-test .` 
If the arguments are not specified the previous default will be used (default yellow colour). 
The consequence is that we will need to build two images, one for test and one for the prod ENV/DB. 

